### PR TITLE
dequeue responsive-image-maps scripts

### DIFF
--- a/draw-attention.php
+++ b/draw-attention.php
@@ -82,3 +82,33 @@ if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
 	add_action( 'plugins_loaded', array( 'DrawAttention_Admin', 'get_instance' ) );
 
 }
+
+
+
+/**
+ * Responsive Image Maps plugin attempts to take over any image map on the page, which interferes with our plugin’s ability to resize and place hotspots correctly.
+ * Please check your list of active plugins to see if you have the Responsive Image Maps plugin installed and activated. If so, we regretfully recommend deactivating this plugin.
+ * It has been abandoned and has not been updated in over 8 years.
+ * Here is a link to our public ticket asking the plugin author to update their plugin: https://wordpress.org/support/topic/conflict-with-draw-attention-plugin-2/
+ * 
+ * Our final solution is to dequeue the Responsive Image Maps plugin’s script if it is active.
+ * And tell WordPress to not load RIM plugin
+ * 
+ */
+function dequeue_outdated_conflicting_scripts(){
+
+	if (!function_exists( 'is_plugin_active' ) ) {
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+	}
+
+	if ( is_plugin_active( 'responsive-image-maps/responsive-image-maps.php' ) ) {
+		wp_dequeue_script( 'jQuery.rwd_image_maps' );
+	}
+}
+
+function temporarily_disable_my_plugin(){
+	remove_action( 'wp_head', 'pn_rim_header_scripts' );
+}
+
+add_action('init', 'temporarily_disable_my_plugin');
+add_action('wp_enqueue_scripts', 'dequeue_outdated_conflicting_scripts', 999 );

--- a/draw-attention.php
+++ b/draw-attention.php
@@ -88,27 +88,30 @@ if ( is_admin() && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
 /**
  * Responsive Image Maps plugin attempts to take over any image map on the page, which interferes with our plugin’s ability to resize and place hotspots correctly.
  * Please check your list of active plugins to see if you have the Responsive Image Maps plugin installed and activated. If so, we regretfully recommend deactivating this plugin.
- * It has been abandoned and has not been updated in over 8 years.
+ * It has been abandoned and has not been updated since 2015.
  * Here is a link to our public ticket asking the plugin author to update their plugin: https://wordpress.org/support/topic/conflict-with-draw-attention-plugin-2/
  * 
  * Our final solution is to dequeue the Responsive Image Maps plugin’s script if it is active.
  * And tell WordPress to not load RIM plugin
  * 
  */
-function dequeue_outdated_conflicting_scripts(){
-
-	if (!function_exists( 'is_plugin_active' ) ) {
-		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+function da_dequeue_conflicting_rim_scripts(){
+	
+	if ( ! function_exists( 'pn_rim_enqueue_scripts' ) ) {
+		return;
 	}
 
-	if ( is_plugin_active( 'responsive-image-maps/responsive-image-maps.php' ) ) {
-		wp_dequeue_script( 'jQuery.rwd_image_maps' );
-	}
+	wp_dequeue_script( 'jQuery.rwd_image_maps' );
 }
 
-function temporarily_disable_my_plugin(){
+function da_disable_rim_plugin(){
+	
+	if ( ! function_exists( 'pn_rim_enqueue_scripts' ) ) {
+		return;
+	}
+	
 	remove_action( 'wp_head', 'pn_rim_header_scripts' );
 }
 
-add_action('init', 'temporarily_disable_my_plugin');
-add_action('wp_enqueue_scripts', 'dequeue_outdated_conflicting_scripts', 999 );
+add_action('init', 'da_disable_rim_plugin');
+add_action('wp_enqueue_scripts', 'da_dequeue_conflicting_rim_scripts', 999 );


### PR DESCRIPTION
## Asana
https://app.asana.com/0/1202852195727075/1203885894834859/f

## Context
An outdated WP plugin interferes with all image maps on all pages, including draw attention image maps. [We have this public ticket asking the developers to update their plugin, and we still have no response.](https://wordpress.org/support/topic/conflict-with-draw-attention-plugin-2/)