### PR TITLE
CI/Release omit the empty_content field so that the title of an empty category will not be included 

### DIFF
--- a/.github/config/changelog_configuration.json
+++ b/.github/config/changelog_configuration.json
@@ -2,13 +2,11 @@
   "categories": [
     {
       "title": "## Fixes",
-      "labels": ["bugfix", "bug"],
-      "empty_content": ""
+      "labels": ["bugfix", "bug"]
     },
     {
       "title": "## Features and Improvements",
-      "labels": ["feature"],
-      "empty_content": ""
+      "labels": ["feature"]
     }
   ],
   "template": "${{CHANGELOG}}",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ on:
         description: "Version type (major, minor, patch or leave empty to release current master branch)"
         required: false
         default: ""
-  pull_request:
     
 
 jobs:


### PR DESCRIPTION
## Asana
-

## Context
When building official change-log, hide PR category title when it has no merged PRs.