### PR TITLE
Update Draw Attention block to use api version 2

### DIFF
--- a/admin/assets/js/draw-attention-block.js
+++ b/admin/assets/js/draw-attention-block.js
@@ -1,21 +1,31 @@
-var el = wp.element.createElement,
-	registerBlockType = wp.blocks.registerBlockType,
-	ServerSideRender = wp.components.ServerSideRender;
+(function(blocks, element, serverSideRender, blockEditor )
+	{
+	var el = element.createElement,
+		registerBlockType = blocks.registerBlockType,
+		ServerSideRender = serverSideRender,
+		useBlockProps = blockEditor.useBlockProps;
 
-registerBlockType( 'draw-attention/image', {
-	title: 'Draw Attention Image',
-	icon: 'images-alt2',
-	category: 'widgets',
+	registerBlockType( 'draw-attention/image', {
+		apiVersion: 2,
+		title: 'Draw Attention Image',
+		icon: 'images-alt2',
+		category: 'widgets',
 
-	edit: function() {
-		return [
-			el( ServerSideRender, {
-				block: 'draw-attention/image'
-			} )
-		];
-	},
-
-	save: function() {
-		return null;
-	},
-} );
+		edit: function(props) {
+			var blockProps = useBlockProps();
+			return el(
+				'div',
+				blockProps,
+				el(ServerSideRender, {
+					block: 'draw-attention/image',
+					attributes: props.attributes,
+				})
+			);
+		},
+	} );
+})(
+	window.wp.blocks,
+	window.wp.element,
+	window.wp.serverSideRender,
+	window.wp.blockEditor
+);

--- a/public/includes/class-block-image.php
+++ b/public/includes/class-block-image.php
@@ -47,7 +47,7 @@ class DrawAttention_Block_Image {
 			wp_register_script(
 				'drawattention-image-block-js',
 				trailingslashit( $this->plugin->get_plugin_url() ) . 'admin/assets/js/draw-attention-block.js',
-				array( 'wp-blocks', 'wp-element', 'wp-components', 'wp-editor' )
+				array( 'wp-blocks', 'wp-element', 'wp-server-side-render', 'wp-block-editor' )
 			);
 
 			wp_register_style(
@@ -56,6 +56,7 @@ class DrawAttention_Block_Image {
 			);
 
 			register_block_type( 'draw-attention/image', array(
+				'api_version' => 2,
 				'editor_script' => 'drawattention-image-block-js',
 				'editor_style' => 'drawattention-image-block-css',
 				'keywords' => array( 'image', 'hotspot', 'map' ),


### PR DESCRIPTION
We can't reproduce it reliably, but we had a couple of reports from customers that our Draw Attention block wasn't working in WordPress 6.2. It weirdly seems to work on some sites and not others. I ruled out theme and plugin conflicts, but there's something else happening that's causing the block to have problems on some installs and not others. 

https://app.asana.com/0/1202131669252825/1204463372846373