### PR TITLE
update master if we bump version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
       # Update branches =====================
       # =====================================
       - name: 'Update branch master'
-        if: steps.build_changelog.outputs.changelog != '' && steps.build_changelog.outputs.pull_requests != ''
+        if:  steps.version.outputs.version != 'current' || ( steps.build_changelog.outputs.changelog != '' && steps.build_changelog.outputs.pull_requests != '' )
         run: |
           git add -A .
           git commit -m "Update to ${{ steps.package-version.outputs.current-version }} [version-bump]"
@@ -174,7 +174,7 @@ jobs:
       # =====================================
       # Cleanup if Needed ===================
       # =====================================
-      - name: "If releasing current, delete tag to avoid conflict"
+      - name: "If tag exists - delete tag to avoid conflict"
         uses: dev-drprasad/delete-tag-and-release@v1.0
         with:
           tag_name: "${{ steps.package-version.outputs.current-version }}"


### PR DESCRIPTION
## Asana
follow-up task to DA release fixes in asana ID 1204553643631715

## Context
When we do a version bump, commit changes to master even if there are no new PRs and no change logs