### PR TITLE
switched order of function parameters so that optional parameter will follow the required param

### DIFF
--- a/public/includes/lib/CMB2/includes/types/CMB2_Type_Multi_Base.php
+++ b/public/includes/lib/CMB2/includes/types/CMB2_Type_Multi_Base.php
@@ -31,7 +31,7 @@ abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 	 * @param  int   $i    Iterator value
 	 * @return string       Gnerated list item html
 	 */
-	public function list_input( $args = array(), $i ) {
+	public function list_input( $args = array(), $i=0 ) {
 		$a = $this->parse_args( 'list_input', array(
 			'type'  => 'radio',
 			'class' => 'cmb2-option',

--- a/public/includes/lib/CMB2/includes/types/CMB2_Type_Multi_Base.php
+++ b/public/includes/lib/CMB2/includes/types/CMB2_Type_Multi_Base.php
@@ -31,7 +31,7 @@ abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 	 * @param  int   $i    Iterator value
 	 * @return string       Gnerated list item html
 	 */
-	public function list_input( $args = array(), $i=0 ) {
+	public function list_input( $args = array(), $i = 0 ) {
 		$a = $this->parse_args( 'list_input', array(
 			'type'  => 'radio',
 			'class' => 'cmb2-option',


### PR DESCRIPTION
## Asana
https://app.asana.com/0/1202852195727075/1204716506134256/f

## Context
Getting rid of a warning reported on DA Pro:
"Deprecated: Required parameter $i follows optional parameter $args in /app/wp-content/plugins/draw-attention-pro/public/includes/lib/cmb2/includes/types/CMB2_Type_Multi_Base.php on line 34"