### PR TITLE
Remove unnecessary reset call in drag-drop featured image functionality

### DIFF
--- a/public/includes/lib/drag-drop-featured-image/index.php
+++ b/public/includes/lib/drag-drop-featured-image/index.php
@@ -442,8 +442,6 @@ class WP_Drag_Drop_Featured_Image_Map {
 										fields.each(function(){
 											$(this).attr('data-image-url', response.image);
 										});
-										hotspotAdmin.reset();
-
 									});
 
 								}


### PR DESCRIPTION
## Implement same fix for the free edition once the parent task is approved

Asana: https://app.asana.com/0/1202852195727079/1209401456647761